### PR TITLE
feat!: skip nullish values from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ defu.arrayFn({
 ### Remarks
 
 - `object` and `defaults` are not modified
-- `null` and `undefined` values are skipped. Please use [defaults-deep](https://www.npmjs.com/package/defaults-deep) or [omit-deep](http://npmjs.com/package/omit-deep) or [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep) if you need to preserve or different behavior.
+- Nullish values ([`null`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null) and [`undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)) are skipped. Please use [defaults-deep](https://www.npmjs.com/package/defaults-deep) or [omit-deep](http://npmjs.com/package/omit-deep) or [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep) if you need to preserve or different behavior.
 - Assignment of `__proto__` and `constructor` keys will be skipped to prevent security issues with object pollution.
 - Will concat `array` values (if default property is defined)
 ```js

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ defu.arrayFn({
 ### Remarks
 
 - `object` and `defaults` are not modified
-- `null` and `undefined` values are skipped same as [defaults-deep](https://www.npmjs.com/package/defaults-deep). Please use either [omit-deep](http://npmjs.com/package/omit-deep) or [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep) if you need to preserve.
+- `null` and `undefined` values are skipped. Please use [defaults-deep](https://www.npmjs.com/package/defaults-deep) or [omit-deep](http://npmjs.com/package/omit-deep) or [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep) if you need to preserve or different behavior.
 - Assignment of `__proto__` and `constructor` keys will be skipped to prevent security issues with object pollution.
 - Will concat `array` values (if default property is defined)
 ```js

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ defu.arrayFn({
 ### Remarks
 
 - `object` and `defaults` are not modified
-- `null` values are skipped same as [defaults-deep](https://www.npmjs.com/package/defaults-deep). Please use either [omit-deep](http://npmjs.com/package/omit-deep) or [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep) if you need to preserve.
+- `null` and `undefined` values are skipped same as [defaults-deep](https://www.npmjs.com/package/defaults-deep). Please use either [omit-deep](http://npmjs.com/package/omit-deep) or [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep) if you need to preserve.
 - Assignment of `__proto__` and `constructor` keys will be skipped to prevent security issues with object pollution.
 - Will concat `array` values (if default property is defined)
 ```js

--- a/src/defu.ts
+++ b/src/defu.ts
@@ -19,7 +19,7 @@ function _defu<T> (baseObj: T, defaults: any, namespace: string = '.', merger?: 
 
     const val = baseObj[key]
 
-    if (val === null) {
+    if (val === null || val === undefined) {
       continue
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,17 +7,19 @@ export type Merger = <T extends Input, K extends keyof T>(
   namespace: string
 ) => any;
 
+type nullish = null | undefined | void
+
 type MergeObjects<
   Destination extends Input,
   Defaults extends Input
 > = Destination extends Defaults ? Destination : Omit<Destination, keyof Destination & keyof Defaults> & Omit<Defaults, keyof Destination & keyof Defaults> &
   {
     -readonly [Key in keyof Destination & keyof Defaults]:
-      Destination[Key] extends null
-        ? Defaults[Key] extends null
-          ? null
+      Destination[Key] extends nullish
+        ? Defaults[Key] extends nullish
+          ? nullish
           : Defaults[Key]
-        : Defaults[Key] extends null
+        : Defaults[Key] extends nullish
           ? Destination[Key]
           : Merge<Destination[Key], Defaults[Key]> // eslint-disable-line no-use-before-define
   }
@@ -48,11 +50,11 @@ export type Merge<
   Defaults extends Input
 > =
   // Remove explicitly null types
-  Destination extends null
-  ? Defaults extends null
-    ? null
+  Destination extends nullish
+  ? Defaults extends nullish
+    ? nullish
     : Defaults
-  : Defaults extends null
+  : Defaults extends nullish
     ? Destination
     // Handle arrays
     : Destination extends Array<any>


### PR DESCRIPTION
Before: `defu({ a: undefined }, { a: 1 })` => `{ a: undefined }`

After: `defu({ a: undefined }, { a: 1 })` => `{ a: 1}`

This is breaking behavior from being constant with [defaults-deep](https://www.npmjs.com/package/defaults-deep)