### PR TITLE
chore: add homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "defu",
   "version": "6.0.0",
   "description": "Recursively assign default properties. Lightweight and Fast!",
+  "homepage": "https://github.com/unjs/defu",
   "repository": "unjs/defu",
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
Fix the repository handling in `package.json` based on the official doc page: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

Add the homepage link to the repository based on https://docs.npmjs.com/cli/v6/configuring-npm/package-json#homepage