### PR TITLE
fix: restore renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "@nuxtjs"
+    "github>unjs/renovate-config"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": [
-    "eslint-config-unjs"
-  ],
-  "rules": {}
+    "@nuxtjs"
+  ]
 }


### PR DESCRIPTION
Resolves #51

8b44f9321a86daf87b052a2bd1e3bfc2d2cb5d22 destroys `renovate.json`, and the content became same as that of `.eslintrc` file. If there is a reason, like disabling renovate, please let me know and close this PR.