### PR TITLE
feat!: clone support

### DIFF
--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -213,4 +213,12 @@ describe("defu", () => {
       foo: { bar: { modules: "foo.bar:X,Y" } },
     });
   });
+
+  it("should clone the defaults object's values", () => {
+    const ext = createDefu(undefined, { clone: true });
+    const source = { a: [1, 2] };
+    const defaults = { a: { b: 1 } };
+    const result = ext(source, defaults);
+    expect(result.a).not.toBe(source.a);
+  });
 });


### PR DESCRIPTION
Hi, this sould fix #90

Because [structuredClone ](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#browser_compatibility)is not available in all environments: 
If structuredClone is available, we use it otherwise we use JSON.parse(JSON.stringify(value)). 
To have a full support, we need to add polyfills. 

Thank @Caceresenzo for his help 