### PR TITLE
docs: fix the result of the array merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ defuArrayFn({
 - Will concat `array` values (if default property is defined)
 ```js
 console.log(defu({ array: ['b', 'c'] }, { array: ['a'] }))
-// => { array: ['a', 'b', 'c']}
+// => { array: [ 'b', 'c', 'a' ] }
 ```
 
 ## Type

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ defuArrayFn({
 - Will concat `array` values (if default property is defined)
 ```js
 console.log(defu({ array: ['b', 'c'] }, { array: ['a'] }))
-// => { array: [ 'b', 'c', 'a' ] }
+// => { array: ['b', 'c', 'a'] }
 ```
 
 ## Type


### PR DESCRIPTION
The result of `console.log(defu({ array: ['b', 'c'] }, { array: ['a'] }))` should be `{ array: ['b', 'c', 'a'] }` other than `{ array: ['a', 'b', 'c']}` :)