### PR TITLE
fix: only merge plain objects

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -48,7 +48,7 @@ function _defu<T>(
 // From sindresorhus/is-plain-obj
 // MIT License
 // Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-function _isPlainObject(value) {
+function _isPlainObject(value: unknown): boolean {
   if (value === null || typeof value !== "object") {
     return false;
   }

--- a/src/defu.ts
+++ b/src/defu.ts
@@ -1,9 +1,5 @@
 import type { Merger, DefuFn as DefuFunction, DefuInstance } from "./types";
 
-function isObject(value: any) {
-  return value !== null && typeof value === "object";
-}
-
 // Base function to apply defaults
 function _defu<T>(
   baseObject: T,
@@ -11,7 +7,7 @@ function _defu<T>(
   namespace = ".",
   merger?: Merger,
 ): T {
-  if (!isObject(defaults)) {
+  if (!_isPlainObject(defaults)) {
     return _defu(baseObject, {}, namespace, merger);
   }
 
@@ -34,7 +30,7 @@ function _defu<T>(
 
     if (Array.isArray(value) && Array.isArray(object[key])) {
       object[key] = [...value, ...object[key]];
-    } else if (isObject(value) && isObject(object[key])) {
+    } else if (_isPlainObject(value) && _isPlainObject(object[key])) {
       object[key] = _defu(
         value,
         object[key],
@@ -48,6 +44,18 @@ function _defu<T>(
 
   return object;
 }
+
+// From sindresorhus/is-plain-obj
+// MIT License
+// Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+function _isPlainObject(value) {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in value) && !(Symbol.iterator in value);
+}
+
 
 // Create defu wrapper with optional merger and multi arg support
 export function createDefu(merger?: Merger): DefuFunction {

--- a/src/defu.ts
+++ b/src/defu.ts
@@ -49,13 +49,18 @@ function _defu<T>(
 // MIT License
 // Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 function _isPlainObject(value) {
-  if (value === null || typeof value !== 'object') {
+  if (value === null || typeof value !== "object") {
     return false;
   }
   const prototype = Object.getPrototypeOf(value);
-  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in value) && !(Symbol.iterator in value);
+  return (
+    (prototype === null ||
+      prototype === Object.prototype ||
+      Object.getPrototypeOf(prototype) === null) &&
+    !(Symbol.toStringTag in value) &&
+    !(Symbol.iterator in value)
+  );
 }
-
 
 // Create defu wrapper with optional merger and multi arg support
 export function createDefu(merger?: Merger): DefuFunction {

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -57,14 +57,14 @@ describe("defu", () => {
     }
     const result = defu({ test: new Test("a") }, { test: new Test("b") });
     expect(result).toEqual({ test: new Test("a") });
-  })
+  });
 
   it.skip("should assign date properly", () => {
     const date1 = new Date("2020-01-01");
     const date2 = new Date("2020-01-02");
     const result = defu({ date: date1 }, { date: date2 });
     expect(result).toEqual({ date: date2 });
-  })
+  });
 
   it("should correctly merge different object types", () => {
     const fn = () => 42;

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -50,6 +50,22 @@ describe("defu", () => {
     }>();
   });
 
+  it.skip("should avoid merging objects with custom constructor", () => {
+    class Test {
+      // eslint-disable-next-line no-useless-constructor
+      constructor(public value: string) {}
+    }
+    const result = defu({ test: new Test("a") }, { test: new Test("b") });
+    expect(result).toEqual({ test: new Test("a") });
+  })
+
+  it.skip("should assign date properly", () => {
+    const date1 = new Date("2020-01-01");
+    const date2 = new Date("2020-01-02");
+    const result = defu({ date: date1 }, { date: date2 });
+    expect(result).toEqual({ date: date2 });
+  })
+
   it("should correctly merge different object types", () => {
     const fn = () => 42;
     const re = /test/i;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #100

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When merging two objects, we were not checking if two objects are not pure object and also using `Object.assign` to merge even classes, which can lead to unwanted behavior such as merging two `Date` values.

This PR fixes this issue by adding little bit of overhead to the checks using a fork of [is-plain-obj](https://github.com/sindresorhus/is-plain-obj/tree/main)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
