### PR TITLE
fix: merge symbol keys

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -9,12 +9,12 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
   const object = { ...defaults };
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  for (const key of Reflect.ownKeys(baseObject as Record<string | symbol, any>)) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<string | symbol, any>)[key as any];
 
     if (value === null || value === undefined) {
       continue;

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -236,6 +236,30 @@ describe("defu", () => {
     });
   });
 
+  it("merges symbol keys", () => {
+    const a = Symbol("a");
+    const b = Symbol("b");
+    const c = Symbol("c");
+    const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
+    expect(result).toEqual({
+      [a]: "a",
+      [b]: "c",
+      [c]: ["a", "b", "c", "d"],
+    });
+  });
+
+  it("preserves symbol keys from defaults", () => {
+    const s = Symbol("key");
+    const result = defu({}, { [s]: "default" });
+    expect(result[s]).toBe("default");
+  });
+
+  it("overrides symbol keys from base", () => {
+    const s = Symbol("key");
+    const result = defu({ [s]: "override" }, { [s]: "default" });
+    expect(result[s]).toBe("override");
+  });
+
   it("custom merger with namespace", () => {
     const ext = createDefu((obj, key, val, namespace) => {
       // console.log({ obj, key, val, namespace })


### PR DESCRIPTION
## Summary

Fixes #145

`Object.keys()` does not iterate over Symbol keys, causing them to be silently dropped during merge. This changes the iteration to `Reflect.ownKeys()` which includes both string and symbol keys.

## Root Cause

```js
for (const key of Object.keys(baseObject)) { // ← skips Symbol keys
```

The spread in `{ ...defaults }` already copies symbol keys from defaults, but symbol keys from `baseObject` were ignored.

## Fix

```diff
- for (const key of Object.keys(baseObject as Record<string, any>)) {
+ for (const key of Reflect.ownKeys(baseObject as Record<string | symbol, any>)) {
```

## Tests

Added 3 test cases:
- `merges symbol keys` — full merge with override + array concat
- `preserves symbol keys from defaults` — symbol key in defaults only
- `overrides symbol keys from base` — symbol key in base overrides default

All 26 tests pass. Lint and type checks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended property merging to properly handle symbol-keyed properties and non-enumerable keys in addition to traditional enumerable string keys

* **Tests**
  * Added test cases covering symbol key handling including merging with array value concatenation, preserving defaults, and allowing base object overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->