### PR TITLE
chore: improve defu maintenance path

### DIFF
--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -271,4 +271,27 @@ describe("defu", () => {
       },
     });
   });
+
+  it("should ignore Symbol keys on baseObject but preserve them on defaults", () => {
+    const sym = Symbol("test");
+    const result = defu({ [sym]: "a" }, { [sym]: "b", x: 1 });
+    expect(Object.keys(result)).toEqual(["x"]);
+    expect((result as Record<symbol, unknown>)[sym]).toBe("b");
+  });
+
+  it("should merge null-prototype objects like plain objects", () => {
+    const defaults = Object.create(null);
+    defaults.a = 1;
+    defaults.b = { c: 2 };
+    const result = defu({ b: { d: 3 } }, defaults);
+    expect(result).toEqual({ a: 1, b: { c: 2, d: 3 } });
+  });
+
+  it("should convert sparse array holes into undefined when merging arrays", () => {
+    const sparse = [1, , 3];
+    const result = defu({ arr: sparse }, { arr: [4, 5] });
+    expect(result).toEqual({ arr: [1, undefined, 3, 4, 5] });
+    expect(result.arr.length).toBe(5);
+    expect(Object.hasOwn(result.arr, 1)).toBe(true);
+  });
 });


### PR DESCRIPTION
Summary:
- Add edge-case unit tests in test/defu.test.ts covering merge behavior with Symbol keys, null prototype objects, and arrays containing undefined holes — areas currently underspecified in the existing test suite. Pure additive test coverage, no behavior change.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for `defu` with additional test cases to improve reliability and catch edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/defu/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->