### PR TITLE
fix(defuFn): apply merger functions with multiple default objects

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -43,9 +43,22 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
 // Create defu wrapper with optional merger and multi arg support
 export function createDefu(merger?: Merger): DefuFunction {
-  return (...arguments_) =>
+  return (...arguments_) => {
+    if (merger && arguments_.length > 1 && isPlainObject(arguments_[0])) {
+      const [source, ...defaults] = arguments_;
+
+      return _defu(
+        source,
+        // eslint-disable-next-line unicorn/no-array-reduce
+        defaults.reduce((p, c) => _defu(p, c, "", merger), {} as any),
+        "",
+        merger,
+      ) as any;
+    }
+
     // eslint-disable-next-line unicorn/no-array-reduce
-    arguments_.reduce((p, c) => _defu(p, c, "", merger), {} as any);
+    return arguments_.reduce((p, c) => _defu(p, c, "", merger), {} as any);
+  };
 }
 
 // Standard version

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -216,6 +216,36 @@ describe("defu", () => {
     });
   });
 
+  it("defuFn() applies merger functions with multiple defaults", () => {
+    const filterDist = (val: string[]) => val.filter((i) => i !== "dist");
+    const addTwenty = (val: number) => val + 20;
+    const addTen = (val: number) => val + 10;
+
+    expect(
+      defuFn(
+        {
+          count: addTwenty,
+          num: addTen,
+          items: filterDist,
+        },
+        {
+          count: 10,
+          num: 5,
+          items: ["node_modules", "test"],
+        },
+        {
+          count: 5,
+          num: 3,
+          items: ["temp", "dist"],
+        },
+      ),
+    ).toEqual({
+      count: 30,
+      num: 15,
+      items: ["node_modules", "test", "temp"],
+    });
+  });
+
   it("defuArrayFn()", () => {
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const num = () => 20;


### PR DESCRIPTION
## Summary
Fix `defuFn()` when more than two objects are passed and the first object contains merger functions.

## Problem
Fixes #139. With multiple default objects, reducer passes replaced function values with computed results before later defaults were merged, so array merger functions (e.g. filtering `dist`) were skipped on subsequent defaults.

## Fix
When a merger is configured and the first argument is a plain object, merge all trailing defaults first, then apply `_defu()` once against the source object that still contains functions.

Standard `defu()` behavior is unchanged (including non-object first arguments).

## Test plan
- [x] `pnpm test` — 24 passed
- [x] New regression for the #139 reproduction (`count`, `num`, `items` with two defaults)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced merging behavior to support "source + defaults" convention when custom merger functions are provided with multiple arguments.

* **Tests**
  * Added test coverage for merger function application across multiple default arguments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/defu/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->