### PR TITLE
feat: add skipNullish option to preserve null and undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ defuArrayFn(
 ### Remarks
 
 - `object` and `defaults` are not modified
-- Nullish values ([`null`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null) and [`undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)) are skipped. Please use [defaults-deep](https://www.npmjs.com/package/defaults-deep) or [omit-deep](http://npmjs.com/package/omit-deep) or [lodash.defaultsdeep](https://www.npmjs.com/package/lodash.defaultsdeep) if you need to preserve or different behavior.
+- Nullish values ([`null`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null) and [`undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)) are skipped by default. Pass `{ skipNullish: false }` as the last argument to preserve them.
 - Assignment of `__proto__` and `constructor` keys will be skipped to prevent security issues with object pollution.
 - Will concat `array` values (if default property is defined)
 

--- a/src/defu.ts
+++ b/src/defu.ts
@@ -1,10 +1,42 @@
 import { isPlainObject } from "./_utils";
-import type { Merger, DefuFn as DefuFunction, DefuInstance } from "./types";
+import type { DefuOptions, Merger, DefuFn as DefuFunction, DefuInstance } from "./types";
+
+function isDefuOptions(value: unknown): value is DefuOptions {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  const object = value as Record<string, unknown>;
+  const keys = Object.keys(object);
+
+  return keys.length > 0 && keys.every((key) => key === "skipNullish");
+}
+
+function splitDefuArgs(arguments_: unknown[]) {
+  const args = [...arguments_];
+  let options: DefuOptions = {};
+
+  const last = args[args.length - 1];
+  if (isDefuOptions(last)) {
+    options = last;
+    args.pop();
+  }
+
+  return { args, options };
+}
 
 // Base function to apply defaults
-function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger): T {
+function _defu<T>(
+  baseObject: T,
+  defaults: any,
+  namespace = ".",
+  merger?: Merger,
+  options: DefuOptions = {},
+): T {
+  const skipNullish = options.skipNullish !== false;
+
   if (!isPlainObject(defaults)) {
-    return _defu(baseObject, {}, namespace, merger);
+    return _defu(baseObject, {}, namespace, merger, options);
   }
 
   const object = { ...defaults };
@@ -16,7 +48,12 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
     const value = (baseObject as Record<string, any>)[key];
 
-    if (value === null || value === undefined) {
+    if (skipNullish && (value === null || value === undefined)) {
+      continue;
+    }
+
+    if (!skipNullish && (value === null || value === undefined)) {
+      object[key] = value;
       continue;
     }
 
@@ -32,6 +69,7 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
         object[key],
         (namespace ? `${namespace}.` : "") + key.toString(),
         merger,
+        options,
       );
     } else {
       object[key] = value;
@@ -43,9 +81,25 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
 // Create defu wrapper with optional merger and multi arg support
 export function createDefu(merger?: Merger): DefuFunction {
-  return (...arguments_) =>
+  return (...arguments_) => {
+    const { args, options } = splitDefuArgs(arguments_);
+
+    if (merger && args.length > 1 && isPlainObject(args[0])) {
+      const [source, ...defaults] = args;
+
+      return _defu(
+        source,
+        // eslint-disable-next-line unicorn/no-array-reduce
+        defaults.reduce((p, c) => _defu(p, c, "", merger, options), {} as any),
+        "",
+        merger,
+        options,
+      ) as any;
+    }
+
     // eslint-disable-next-line unicorn/no-array-reduce
-    arguments_.reduce((p, c) => _defu(p, c, "", merger), {} as any);
+    return args.reduce((p, c) => _defu(p, c, "", merger, options), {} as any);
+  };
 }
 
 // Standard version
@@ -68,4 +122,4 @@ export const defuArrayFn = createDefu((object, key, currentValue) => {
   }
 });
 
-export type { Defu, DefuFn, DefuInstance } from "./types";
+export type { Defu, DefuFn, DefuInstance, DefuOptions } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,14 @@
 export type Input = Record<string | number | symbol, any>;
 export type IgnoredInput = boolean | number | null | any[] | Record<never, any> | undefined;
 
+export interface DefuOptions {
+  /**
+   * When set to `false`, `null` and `undefined` values from the source object
+   * are preserved instead of being skipped.
+   */
+  skipNullish?: boolean;
+}
+
 export type Merger = <T extends Input, K extends keyof T>(
   object: T,
   key: keyof T,
@@ -41,13 +49,16 @@ export type Defu<S extends Input, D extends Array<Input | IgnoredInput>> = D ext
       : S
   : S;
 
-export type DefuFn = <Source extends Input, Defaults extends Array<Input | IgnoredInput>>(
+export type DefuFn = <
+  Source extends Input,
+  Defaults extends Array<Input | IgnoredInput | DefuOptions>,
+>(
   source: Source,
   ...defaults: Defaults
 ) => Defu<Source, Defaults>;
 
 export interface DefuInstance {
-  <Source extends Input, Defaults extends Array<Input | IgnoredInput>>(
+  <Source extends Input, Defaults extends Array<Input | IgnoredInput | DefuOptions>>(
     source: Source | IgnoredInput,
     ...defaults: Defaults
   ): Defu<Source, Defaults>;

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -23,6 +23,19 @@ describe("defu", () => {
     expectTypeOf(result2).toMatchTypeOf<{ a: string; d: string }>();
   });
 
+  it("should preserve nullish values when skipNullish is false", () => {
+    expect(defu({ a: undefined, b: null }, { a: "c", b: "d" }, { skipNullish: false })).toEqual({
+      a: undefined,
+      b: null,
+    });
+
+    expect(
+      defu({ nested: { a: undefined } }, { nested: { a: "c", b: "d" } }, { skipNullish: false }),
+    ).toEqual({
+      nested: { a: undefined, b: "d" },
+    });
+  });
+
   it("should copy nested values", () => {
     const result = defu({ a: { b: "c" } }, { a: { d: "e" } });
     expect(result).toEqual({


### PR DESCRIPTION
## Summary
- Add optional `{ skipNullish: false }` as the last `defu()` argument
- When enabled, explicit `null` and `undefined` source values override defaults
- Default behavior remains unchanged (nullish values are skipped)

Fixes #95

## Test plan
- [x] `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional skipNullish option to control preservation of null and undefined during merges (defaults to skipping them).

* **Documentation**
  * README updated to document the nullish handling behavior.

* **Tests**
  * Added tests covering preservation of null/undefined when skipNullish is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/defu/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->