### PR TITLE
feat: add onDuplicate option to createDefu

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -1,10 +1,36 @@
 import { isPlainObject } from "./_utils";
-import type { Merger, DefuFn as DefuFunction, DefuInstance } from "./types";
+import type { DefuOptions, Merger, DefuFn as DefuFunction, DefuInstance } from "./types";
+
+function resolveCreateDefuArgs(mergerOrOptions?: Merger | DefuOptions) {
+  if (typeof mergerOrOptions === "function") {
+    return { merger: mergerOrOptions, options: {} as DefuOptions };
+  }
+
+  return { merger: undefined, options: mergerOrOptions ?? {} };
+}
+
+function notifyDuplicate(
+  options: DefuOptions,
+  key: string,
+  value: unknown,
+  defaults: Record<string, unknown>,
+  object: Record<string, unknown>,
+) {
+  if (options.onDuplicate && Object.hasOwn(defaults, key) && Object.is(object[key], value)) {
+    options.onDuplicate(object, key, value);
+  }
+}
 
 // Base function to apply defaults
-function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger): T {
+function _defu<T>(
+  baseObject: T,
+  defaults: any,
+  namespace = ".",
+  merger?: Merger,
+  options: DefuOptions = {},
+): T {
   if (!isPlainObject(defaults)) {
-    return _defu(baseObject, {}, namespace, merger);
+    return _defu(baseObject, {}, namespace, merger, options);
   }
 
   const object = { ...defaults };
@@ -32,8 +58,10 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
         object[key],
         (namespace ? `${namespace}.` : "") + key.toString(),
         merger,
+        options,
       );
     } else {
+      notifyDuplicate(options, key, value, defaults, object);
       object[key] = value;
     }
   }
@@ -42,10 +70,12 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 }
 
 // Create defu wrapper with optional merger and multi arg support
-export function createDefu(merger?: Merger): DefuFunction {
+export function createDefu(mergerOrOptions?: Merger | DefuOptions): DefuFunction {
+  const { merger, options } = resolveCreateDefuArgs(mergerOrOptions);
+
   return (...arguments_) =>
     // eslint-disable-next-line unicorn/no-array-reduce
-    arguments_.reduce((p, c) => _defu(p, c, "", merger), {} as any);
+    arguments_.reduce((p, c) => _defu(p, c, "", merger, options), {} as any) as any;
 }
 
 // Standard version
@@ -68,4 +98,4 @@ export const defuArrayFn = createDefu((object, key, currentValue) => {
   }
 });
 
-export type { Defu, DefuFn, DefuInstance } from "./types";
+export type { Defu, DefuFn, DefuInstance, DefuOptions } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 export type Input = Record<string | number | symbol, any>;
 export type IgnoredInput = boolean | number | null | any[] | Record<never, any> | undefined;
 
+export interface DefuOptions {
+  onDuplicate?: (object: Record<string, unknown>, key: string, value: unknown) => void;
+}
+
 export type Merger = <T extends Input, K extends keyof T>(
   object: T,
   key: keyof T,

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -23,6 +23,26 @@ describe("defu", () => {
     expectTypeOf(result2).toMatchTypeOf<{ a: string; d: string }>();
   });
 
+  it("calls onDuplicate when source overrides default with same value", () => {
+    const duplicates: Array<{ key: string; value: unknown; object: Record<string, unknown> }> = [];
+
+    const defuWithDuplicateHandler = createDefu({
+      onDuplicate(object, key, value) {
+        duplicates.push({ key, value, object });
+      },
+    });
+
+    defuWithDuplicateHandler(
+      { a: "c", nested: { b: 1 } },
+      { a: "c", nested: { b: 1, c: 2 }, d: "e" },
+    );
+
+    expect(duplicates).toEqual([
+      { key: "a", value: "c", object: { a: "c", nested: { b: 1, c: 2 }, d: "e" } },
+      { key: "b", value: 1, object: { b: 1, c: 2 } },
+    ]);
+  });
+
   it("should copy nested values", () => {
     const result = defu({ a: { b: "c" } }, { a: { d: "e" } });
     expect(result).toEqual({


### PR DESCRIPTION
## Summary

- Adds optional `onDuplicate` callback to `createDefu()` as suggested in #128
- Invokes the callback when a source value overrides an existing default with the same value (including nested keys)
- Keeps merge behavior unchanged; the callback is side-effect only for logging/telemetry

## Test plan

- [x] `pnpm test` (lint, types, vitest)
- [x] Regression test covers top-level and nested duplicate overrides

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * createDefu can now accept configuration options to customize behavior, including a callback invoked when a duplicate key/value is encountered during merging.

* **Type Exports**
  * Added a public type for the new configuration options to support the callback.

* **Tests**
  * Added a test covering duplicate-key handling and verification that the callback is invoked with the expected data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/defu/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->