### PR TITLE
fix: merge Symbol keys using Reflect.ownKeys

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -7,14 +7,14 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
     return _defu(baseObject, {}, namespace, merger);
   }
 
-  const object = { ...defaults };
+  const object = { ...defaults } as Record<string | symbol, any>;
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  for (const key of Reflect.ownKeys(baseObject as Record<string | symbol, any>)) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<string | symbol, any>)[key];
 
     if (value === null || value === undefined) {
       continue;


### PR DESCRIPTION
## Summary

Adds support for merging Symbol-keyed properties by using `Reflect.ownKeys()` instead of `Object.keys()`.

## Changes

- `src/defu.ts`: Changed `Object.keys()` to `Reflect.ownKeys()` to iterate over both string and Symbol keys

## Why

`Object.keys()` excludes Symbol properties, causing `defu` to silently drop Symbol-keyed properties during deep merge. `Reflect.ownKeys()` returns all own property keys including Symbols.

Closes #145