### PR TITLE
fix: attach fn, arrayFn, extend to defu function to match its type

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -48,10 +48,6 @@ export function createDefu(merger?: Merger): DefuFunction {
     arguments_.reduce((p, c) => _defu(p, c, "", merger), {} as any);
 }
 
-// Standard version
-export const defu = createDefu() as DefuInstance;
-export default defu;
-
 // Custom version with function merge support
 export const defuFn = createDefu((object, key, currentValue) => {
   if (object[key] !== undefined && typeof currentValue === "function") {
@@ -67,5 +63,14 @@ export const defuArrayFn = createDefu((object, key, currentValue) => {
     return true;
   }
 });
+
+// Standard version with backward-compatible fn, arrayFn, extend properties
+export const defu = Object.assign(createDefu(), {
+  fn: defuFn,
+  arrayFn: defuArrayFn,
+  extend: createDefu,
+}) as DefuInstance;
+
+export default defu;
 
 export type { Defu, DefuFn, DefuInstance } from "./types";


### PR DESCRIPTION
DefuInstance interface declares these properties but defu = createDefu() just returns a bare function, the as DefuInstance cast was lying to TypeScript. Anyone calling defu.fn(), defu.arrayFn(), or defu.extend() would get a runtime crash despite passing typecheck.

Reordered defuFn/defuArrayFn before defu so they can be referenced, then used Object.assign to attach them to the function object. CJS bridge (lib/defu.cjs) auto-picks these up via module.exports = defu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the main export with additional utility functions and helper properties for enhanced flexibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->