### PR TITLE
fix: merge symbol-keyed properties

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -9,12 +9,19 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
   const object = { ...defaults };
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  const keys: Array<string | symbol> = [
+    ...Object.keys(baseObject as Record<string, any>),
+    ...Object.getOwnPropertySymbols(baseObject as Record<string | symbol, any>).filter((s) =>
+      Object.prototype.propertyIsEnumerable.call(baseObject, s),
+    ),
+  ];
+
+  for (const key of keys) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<string | symbol, any>)[key];
 
     if (value === null || value === undefined) {
       continue;

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -271,4 +271,10 @@ describe("defu", () => {
       },
     });
   });
+
+  it("should merge symbol-keyed properties (issue #145)", () => {
+    const [a, b, c] = [Symbol("a"), Symbol("b"), Symbol("c")];
+    const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
+    expect(result).toEqual({ [a]: "a", [b]: "c", [c]: ["a", "b", "c", "d"] });
+  });
 });


### PR DESCRIPTION
Closes #145

## Problem

`_defu` iterated only `Object.keys(baseObject)` which yields string keys only. Meanwhile the `{ ...defaults }` spread on line 10 correctly copies Symbol-keyed properties from `defaults`. The net result: the `baseObject`'s Symbol-keyed values were never visited, so `defaults` values always won (i.e. Symbol keys were effectively not merged at all).

## Fix

Collect own enumerable Symbol keys alongside string keys before the merge loop, using `Object.getOwnPropertySymbols` filtered by `Object.prototype.propertyIsEnumerable`. The same merge semantics (first-arg precedence, array concat, recursive plain-object merge, `merger` hook) apply to Symbol keys as to string keys.

```ts
const keys: Array<string | symbol> = [
  ...Object.keys(baseObject as Record<string, any>),
  ...Object.getOwnPropertySymbols(baseObject as Record<string | symbol, any>).filter((s) =>
    Object.prototype.propertyIsEnumerable.call(baseObject, s),
  ),
];
```

## Test

Added a regression test that matches the exact repro from the issue:

```ts
const [a, b, c] = [Symbol("a"), Symbol("b"), Symbol("c")];
const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
expect(result).toEqual({ [a]: "a", [b]: "c", [c]: ["a", "b", "c", "d"] });
```

The test fails on the original code and passes with the fix. All 24 tests pass; `oxlint` and `oxfmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Symbol properties are now correctly merged in addition to string-keyed properties. Array values for symbol properties are properly concatenated during merge operations.

* **Tests**
  * Added test coverage validating symbol property merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->