### PR TITLE
docs: add TaskBounty coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Assign default properties, recursively. Lightweight and Fast.
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![bundle][bundle-src]][bundle-href]
 [![Codecov][codecov-src]][codecov-href]
+[![Coverage][taskbounty-coverage-src]][taskbounty-coverage-href]
 [![License][license-src]][license-href]
 
 ## Install
@@ -165,6 +166,8 @@ MIT. Made with 💖
 [npm-downloads-href]: https://npmjs.com/package/defu
 [codecov-src]: https://img.shields.io/codecov/c/gh/unjs/defu/main?style=flat&colorA=18181B&colorB=F0DB4F
 [codecov-href]: https://codecov.io/gh/unjs/defu
+[taskbounty-coverage-src]: https://www.task-bounty.com/badge/coverage/unjs/defu.svg
+[taskbounty-coverage-href]: https://www.task-bounty.com/coverage-check/unjs/defu
 [bundle-src]: https://img.shields.io/bundlephobia/minzip/defu?style=flat&colorA=18181B&colorB=F0DB4F
 [bundle-href]: https://bundlephobia.com/result?p=defu
 [license-src]: https://img.shields.io/github/license/unjs/defu.svg?style=flat&colorA=18181B&colorB=F0DB4F


### PR DESCRIPTION
## Summary
- Add the optional TaskBounty live coverage badge to the README badge list.
- Use the exact badge image and result page URLs from the issue.

## Verification
- Checked README contains the badge and reference links.
- Ran `git diff --check`.
- Ran added-line security scan: 0 findings.
- Independent review passed; noted only that the badge loads an external TaskBounty resource.

Closes #175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Coverage badge to the README displaying project coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->