### PR TITLE
fix: apply defuFn/defuArrayFn functions to merged result of all defaults

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -53,19 +53,38 @@ export const defu = createDefu() as DefuInstance;
 export default defu;
 
 // Custom version with function merge support
-export const defuFn = createDefu((object, key, currentValue) => {
+const _defuFnMerger: Merger = (object, key, currentValue) => {
   if (object[key] !== undefined && typeof currentValue === "function") {
     object[key] = currentValue(object[key]);
     return true;
   }
-});
+};
 
 // Custom version with function merge support only for defined arrays
-export const defuArrayFn = createDefu((object, key, currentValue) => {
+const _defuArrayFnMerger: Merger = (object, key, currentValue) => {
   if (Array.isArray(object[key]) && typeof currentValue === "function") {
     object[key] = currentValue(object[key]);
     return true;
   }
-});
+};
+
+// With more than two arguments, functions from the first argument must be
+// applied to the fully-merged result of all subsequent defaults. Without
+// this, the function is consumed on the first match and subsequent defaults
+// can re-introduce values that the function was supposed to transform.
+function _createDefuWithFnMerger(merger: Merger): DefuFunction {
+  return (...arguments_) =>
+    _defu(
+      arguments_[0],
+      // eslint-disable-next-line unicorn/no-array-reduce
+      arguments_.slice(1).reduce((p, c) => _defu(p, c, "", merger), {} as any),
+      "",
+      merger,
+    ) as any;
+}
+
+export const defuFn = _createDefuWithFnMerger(_defuFnMerger) as DefuInstance;
+
+export const defuArrayFn = _createDefuWithFnMerger(_defuArrayFnMerger) as DefuInstance;
 
 export type { Defu, DefuFn, DefuInstance } from "./types";

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -216,6 +216,33 @@ describe("defu", () => {
     });
   });
 
+  it("defuFn() applies function to merged result of all defaults", () => {
+    const filterDist = (val: string[]) => val.filter((i) => i !== "dist");
+    const addTwenty = (val: number) => val + 20;
+    const addTen = (val: number) => val + 10;
+    expect(
+      defuFn(
+        {
+          count: addTwenty,
+          num: addTen,
+          items: filterDist,
+        },
+        {
+          count: 10,
+          num: 5,
+          items: ["node_modules", "test"],
+        },
+        {
+          items: ["temp", "dist"],
+        },
+      ),
+    ).toEqual({
+      count: 30,
+      num: 15,
+      items: ["node_modules", "test", "temp"],
+    });
+  });
+
   it("defuArrayFn()", () => {
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const num = () => 20;


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #139

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📖 Description

When `defuFn` (or `defuArrayFn`) receives more than two arguments, the transform function in the first argument is applied only to the **second** argument's value. Any subsequent defaults can then re-introduce values that the transform was meant to filter/transform — because by the third iteration the function has already been replaced by its output.

**Root cause:** `createDefu` reduces all arguments left-to-right: `_defu(_defu(a, b), c)`. After `_defu(a, b)`, any functions in `a` have been consumed and replaced with their results. When `_defu(result, c)` runs, there is no function left to apply to the merged array/value from `c`.

**Fix:** For `defuFn` and `defuArrayFn`, merge all defaults (arguments 2..n) first, then apply the function-bearing first argument to that combined result:

```
_defu(arguments_[0], reduce(arguments_.slice(1)), "", merger)
```

This ensures transform functions see the **fully-merged** value of all defaults rather than just the first matching one.

**Example (from #139):**

```ts
const filterDist = (val: string[]) => val.filter(i => i !== 'dist')

defuFn(
  { items: filterDist },
  { items: ['node_modules', 'test'] },
  { items: ['temp', 'dist'] },   // 'dist' was sneaking back in
)

// Before: { items: ['node_modules', 'test', 'temp', 'dist'] }
// After:  { items: ['node_modules', 'test', 'temp'] }  ✓
```

Behavior for 2-argument calls is unchanged. Regular `defu` is also unchanged (the fix only applies to `defuFn`/`defuArrayFn`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Modified function default behavior to apply to the fully merged result across multiple defaults

* **Tests**
  * Added test coverage for function default merging scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->