### PR TITLE
fix: handle symbol keys in defu (#145)

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -38,6 +38,31 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
     }
   }
 
+  for (const key of Object.getOwnPropertySymbols(baseObject)) {
+    const value = (baseObject as any)[key];
+
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    if (merger && merger(object, key, value, namespace)) {
+      continue;
+    }
+
+    if (Array.isArray(value) && Array.isArray(object[key])) {
+      object[key] = [...value, ...object[key]];
+    } else if (isPlainObject(value) && isPlainObject(object[key])) {
+      object[key] = _defu(
+        value,
+        object[key],
+        (namespace ? `${namespace}.` : "") + key.toString(),
+        merger,
+      );
+    } else {
+      object[key] = value;
+    }
+  }
+
   return object;
 }
 

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -271,4 +271,14 @@ describe("defu", () => {
       },
     });
   });
+
+  it("should handle symbol keys (#145)", () => {
+    const [a, b, c] = [Symbol("a"), Symbol("b"), Symbol("c")];
+    const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
+    expect(result).toEqual({
+      [a]: "a",
+      [b]: "c",
+      [c]: ["a", "b", "c", "d"],
+    });
+  });
 });


### PR DESCRIPTION
Closes #145

The `Object.keys()` method only returns string keys, not symbol keys.
This caused symbol keys from the base object to be ignored during merging,
while symbol keys from defaults objects were copied via the spread operator.

### Changes

- Added a second loop to iterate over `Object.getOwnPropertySymbols(baseObject)`
- Applied the same merging logic (array concatenation, deep merging) to symbol keys
- Added test case for symbol key merging

### Testing

All 22 tests pass, including the new test for symbol key merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge and default operations now support symbol-keyed properties with the same behaviors as string-keyed properties, including array concatenation and recursive object merging

* **Tests**
  * Added test coverage for symbol-keyed property handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->