### PR TITLE
fix: merge symbol keys instead of overwriting them

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -24,3 +24,15 @@ export function isPlainObject(value: unknown): boolean {
 
   return true;
 }
+
+// Own enumerable keys, including symbol keys. Mirrors the keys copied by an
+// object spread (`{ ...object }`), unlike `Object.keys` which omits symbols.
+export function getOwnEnumerableKeys(object: Record<string | symbol, any>): Array<string | symbol> {
+  const keys: Array<string | symbol> = Object.keys(object);
+  for (const symbol of Object.getOwnPropertySymbols(object)) {
+    if (Object.prototype.propertyIsEnumerable.call(object, symbol)) {
+      keys.push(symbol);
+    }
+  }
+  return keys;
+}

--- a/src/defu.ts
+++ b/src/defu.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "./_utils";
+import { isPlainObject, getOwnEnumerableKeys } from "./_utils";
 import type { Merger, DefuFn as DefuFunction, DefuInstance } from "./types";
 
 // Base function to apply defaults
@@ -9,12 +9,15 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
   const object = { ...defaults };
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  // Iterate enumerable own keys including symbols, mirroring the `{ ...defaults }`
+  // spread above. `Object.keys` skips symbol keys, so they would otherwise be
+  // overwritten by `defaults` instead of merged. See unjs/defu#145.
+  for (const key of getOwnEnumerableKeys(baseObject as Record<string | symbol, any>)) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<string | symbol, any>)[key];
 
     if (value === null || value === undefined) {
       continue;

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -135,6 +135,35 @@ describe("defu", () => {
     }
   });
 
+  it("should merge symbol keys", () => {
+    const a = Symbol("a");
+    const b = Symbol("b");
+    const c = Symbol("c");
+
+    const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
+
+    expect(result).toEqual({ [a]: "a", [b]: "c", [c]: ["a", "b", "c", "d"] });
+  });
+
+  it("should recursively merge nested symbol keys", () => {
+    const s = Symbol("s");
+
+    const result = defu({ nested: { [s]: { a: 1 } } }, { nested: { [s]: { b: 2 } } });
+
+    expect(result).toEqual({ nested: { [s]: { a: 1, b: 2 } } });
+  });
+
+  it("should ignore non-enumerable symbol keys", () => {
+    const s = Symbol("s");
+    const base = {};
+    Object.defineProperty(base, s, { value: "x", enumerable: false });
+
+    const result = defu(base, { foo: 1 });
+
+    expect(Object.getOwnPropertySymbols(result)).toEqual([]);
+    expect(result).toEqual({ foo: 1 });
+  });
+
   it("should ignore non-object arguments", () => {
     expect(defu(null, { foo: 1 }, false, 123, { bar: 2 })).toEqual({
       foo: 1,

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -153,6 +153,21 @@ describe("defu", () => {
     expect(result).toEqual({ nested: { [s]: { a: 1, b: 2 } } });
   });
 
+  it("should merge symbol keys with a custom merger", () => {
+    const s = Symbol("s");
+    const customDefu = createDefu((object, key, value) => {
+      const record = object as Record<PropertyKey, unknown>;
+      if (key === s && typeof record[key] === "string") {
+        record[key] = `${value}:${record[key]}`;
+        return true;
+      }
+    });
+
+    const result = customDefu({ [s]: "base" }, { [s]: "default" });
+
+    expect(result).toEqual({ [s]: "base:default" });
+  });
+
   it("should ignore non-enumerable symbol keys", () => {
     const s = Symbol("s");
     const base = {};


### PR DESCRIPTION
## Summary

Fixes #145.

`_defu` iterated over the base object with `Object.keys(baseObject)`, which **skips symbol keys**. The result object is built from `{ ...defaults }`, and spread **does** copy enumerable symbol keys. So symbol-keyed properties from later (lower-priority) arguments overwrote earlier (higher-priority) ones instead of being merged.

```js
const [a, b, c] = [Symbol("a"), Symbol("b"), Symbol("c")];
defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });

// before: { [a]: "bbb", [b]: "c", [c]: ["c", "d"] }   ❌ symbol keys not merged
// after:  { [a]: "a",   [b]: "c", [c]: ["a","b","c","d"] }  ✅
```

## Changes

- Add `getOwnEnumerableKeys` to `src/_utils.ts` — returns own **enumerable** keys including symbols, mirroring object-spread semantics. Non-enumerable symbols stay excluded (consistent with how `Object.keys` excludes non-enumerable string keys and with the spread used to build the result).
- Use it in `_defu` instead of `Object.keys`.

This keeps recursive merging, array concat, and the merger callback working for symbol keys too.

## Tests

Added three regression tests to `test/defu.test.ts`:
- merging symbol keys across arguments (the issue's reproduction)
- recursive merge of nested symbol-keyed objects
- non-enumerable symbol keys are ignored

All checks pass locally: `pnpm lint`, `pnpm test:types`, and `pnpm vitest run` (26 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default merging now includes enumerable symbol-keyed properties, aligning more closely with standard object spread behavior.
  * Added support for collecting all own enumerable keys, including symbols.

* **Bug Fixes**
  * Improved merging for nested objects and arrays when symbol keys are present.
  * Non-enumerable symbol properties remain excluded from merged results.

* **Tests**
  * Added coverage for symbol-key merging scenarios, including custom merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->