### PR TITLE
docs: fix typo in Array Function Merger section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ defuArrayFn(
   */
 ```
 
-**Note:** the function is called only if the value defined in defaults is an aray.
+**Note:** the function is called only if the value defined in defaults is an array.
 
 ### Remarks
 


### PR DESCRIPTION
Fixes "an aray" → "an array" in the Array Function Merger documentation.

Spotted while reading through the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the “Array Function Merger” note in the README so it correctly states when the callback is triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->