### PR TITLE
fix: merge symbol keys from base object

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -9,12 +9,20 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
   const object = { ...defaults };
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  // Merge own enumerable string and symbol keys, mirroring the spread above.
+  const baseKeys: (string | symbol)[] = [
+    ...Object.keys(baseObject as Record<string, any>),
+    ...Object.getOwnPropertySymbols(baseObject as object).filter((key) =>
+      Object.prototype.propertyIsEnumerable.call(baseObject, key),
+    ),
+  ];
+
+  for (const key of baseKeys) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<PropertyKey, any>)[key];
 
     if (value === null || value === undefined) {
       continue;

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -135,6 +135,22 @@ describe("defu", () => {
     }
   });
 
+  it("should merge symbol keys", () => {
+    const a = Symbol("a");
+    const b = Symbol("b");
+    const c = Symbol("c");
+    const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
+    expect(result).toEqual({ [a]: "a", [b]: "c", [c]: ["a", "b", "c", "d"] });
+  });
+
+  it("should ignore non-enumerable symbol keys", () => {
+    const hidden = Symbol("hidden");
+    const base = {};
+    Object.defineProperty(base, hidden, { value: 1, enumerable: false });
+    const result = defu(base, {});
+    expect(Object.getOwnPropertySymbols(result)).toEqual([]);
+  });
+
   it("should ignore non-object arguments", () => {
     expect(defu(null, { foo: 1 }, false, 123, { bar: 2 })).toEqual({
       foo: 1,

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -143,6 +143,12 @@ describe("defu", () => {
     expect(result).toEqual({ [a]: "a", [b]: "c", [c]: ["a", "b", "c", "d"] });
   });
 
+  it("should recursively merge symbol-keyed nested objects", () => {
+    const sym = Symbol("nested");
+    const result = defu({ [sym]: { x: 1 } }, { [sym]: { y: 2 } });
+    expect(result).toEqual({ [sym]: { x: 1, y: 2 } });
+  });
+
   it("should ignore non-enumerable symbol keys", () => {
     const hidden = Symbol("hidden");
     const base = {};


### PR DESCRIPTION
## Summary

`defu` drops symbol keys from the base object. `_defu` iterates the base
with `Object.keys`, which skips symbols, while `{ ...defaults }` spreads
them in from the defaults — so a base symbol key is silently overridden
by the defaults instead of taking precedence.

```ts
const a = Symbol("a")
defu({ [a]: "a" }, { [a]: "bbb" })
// before: { [a]: "bbb" }  ❌
// after:  { [a]: "a" }     ✅
```

## Fix

Iterate the base object's own **enumerable** symbol keys alongside its
string keys, so they merge with the same precedence, array-concat and
nested-merge semantics. Non-enumerable and inherited keys stay excluded,
matching existing string-key behavior (the `__proto__`/`constructor`
guard is unaffected — a symbol can't be either).

## Tests

- `should merge symbol keys` — base precedence, defaults-only symbol, and
  array concat for a symbol key (the repro from #145)
- `should ignore non-enumerable symbol keys` — locks the enumerable-only semantics

`pnpm test` (oxlint + tsgo + vitest) passes, 25/25.

Closes #145

_AI-assisted (Claude Code); I reviewed and verified every line. Disclosure is also in the commit trailer._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default merging to include enumerable symbol-keyed properties, including correct handling for nested symbol-keyed objects.
  * Kept existing protections that skip special prototype-related properties during merges.
* **Tests**
  * Added more test coverage for merging enumerable symbol keys (including array concatenation behavior).
  * Added assertions that non-enumerable symbol properties are not included in merged results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->