### PR TITLE
feat: support Symbol keys in defu merge

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -9,12 +9,12 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
   const object = { ...defaults };
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  for (const key of Reflect.ownKeys(baseObject as Record<string | symbol, any>).filter((k) => Object.prototype.propertyIsEnumerable.call(baseObject, k))) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<string | symbol, any>)[key];
 
     if (value === null || value === undefined) {
       continue;


### PR DESCRIPTION
Closes #145.

defu merges string keyed properties but silently ignores Symbol keys (Object.keys omits them), so symbol keyed base values aren't applied and symbol keyed arrays aren't merged. Iterate over Reflect.ownKeys filtered to enumerable properties so both string and symbol keys are merged (scalars override, arrays concatenate, plain objects recurse), matching the issue's exact reproduction.