### PR TITLE
fix(defu): support Symbol keys when merging objects

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -10,7 +10,11 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
   const object = { ...defaults };
 
   for (const key of Reflect.ownKeys(baseObject as Record<string | symbol, any>)) {
-    if (key === "__proto__" || key === "constructor") {
+    if (
+      key === "__proto__" ||
+      key === "constructor" ||
+      !Object.prototype.propertyIsEnumerable.call(baseObject, key)
+    ) {
       continue;
     }
 

--- a/src/defu.ts
+++ b/src/defu.ts
@@ -9,18 +9,18 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
   const object = { ...defaults };
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  for (const key of Reflect.ownKeys(baseObject as Record<string | symbol, any>)) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<string | symbol, any>)[key];
 
     if (value === null || value === undefined) {
       continue;
     }
 
-    if (merger && merger(object, key, value, namespace)) {
+    if (merger && merger(object, key as any, value, namespace)) {
       continue;
     }
 

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -271,4 +271,9 @@ describe("defu", () => {
       },
     });
   });
+  it("merges symbol keys properly", () => {
+    const [a, b, c] = [Symbol("a"), Symbol("b"), Symbol("c")];
+    const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
+    expect(result).toEqual({ [a]: "a", [b]: "c", [c]: ["a", "b", "c", "d"] });
+  });
 });

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -276,4 +276,11 @@ describe("defu", () => {
     const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
     expect(result).toEqual({ [a]: "a", [b]: "c", [c]: ["a", "b", "c", "d"] });
   });
+  it("does not copy non-enumerable properties", () => {
+    const base = {};
+    Object.defineProperty(base, "hidden", { value: "secret", enumerable: false });
+    const result = defu(base, { fallback: "value" });
+    expect(result).toEqual({ fallback: "value" });
+    expect((result as any).hidden).toBeUndefined();
+  });
 });


### PR DESCRIPTION
<!-- Auto-closing issue -->
Resolves #145

### Summary

Enables symbol keys to be preserved and merged correctly between base objects and defaults.

### Context & Cause

Previously, `_defu` iterated over base object keys using `Object.keys(baseObject)`, which only returns enumerable string keys. Consequently, any `Symbol` keys present on the primary object were ignored during iteration and overwritten when defaults spread via `{ ...defaults }`.

### Solution

- Switched key iteration in `_defu` from `Object.keys` to `Reflect.ownKeys`.
- Updated typings for base object to `Record<string | symbol, any>`.
- Added unit test verifying symbol property precedence and array merging.

### Verification

- `pnpm test` passed 100% (lint, typecheck, unit tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object merging to support symbol-keyed properties.
  * Preserves existing symbol values, adds missing symbol properties, and combines symbol-keyed arrays correctly.
  * Excludes non-enumerable and inherited properties from merged results.

* **Tests**
  * Added coverage for symbol-keyed properties and exclusion of non-enumerable properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->