### PR TITLE
fix: merge symbol keys

### DIFF
--- a/src/defu.ts
+++ b/src/defu.ts
@@ -9,12 +9,22 @@ function _defu<T>(baseObject: T, defaults: any, namespace = ".", merger?: Merger
 
   const object = { ...defaults };
 
-  for (const key of Object.keys(baseObject as Record<string, any>)) {
+  // Merge both string and (enumerable) symbol keys. The `Input` type allows
+  // symbol keys and `{ ...defaults }` already carries the defaults' symbols
+  // over, so the base object's symbol keys must be merged too.
+  const baseKeys: Array<string | symbol> = [
+    ...Object.keys(baseObject as Record<string, any>),
+    ...Object.getOwnPropertySymbols(baseObject as object).filter((symbol) =>
+      Object.prototype.propertyIsEnumerable.call(baseObject, symbol),
+    ),
+  ];
+
+  for (const key of baseKeys) {
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
 
-    const value = (baseObject as Record<string, any>)[key];
+    const value = (baseObject as Record<string | symbol, any>)[key];
 
     if (value === null || value === undefined) {
       continue;

--- a/test/defu.test.ts
+++ b/test/defu.test.ts
@@ -255,6 +255,18 @@ describe("defu", () => {
     });
   });
 
+  it("should merge symbol keys", () => {
+    const a = Symbol("a");
+    const b = Symbol("b");
+    const c = Symbol("c");
+    const result = defu({ [a]: "a", [c]: ["a", "b"] }, { [a]: "bbb", [b]: "c", [c]: ["c", "d"] });
+    expect(result).toEqual({
+      [a]: "a",
+      [b]: "c",
+      [c]: ["a", "b", "c", "d"],
+    });
+  });
+
   it("works with asterisk-import", () => {
     expect(
       defu(asteriskImport, {


### PR DESCRIPTION
## Bug

Closes #145.

`defu` drops **symbol-keyed** properties from the higher-priority (base) object, even though `Input` is typed `Record<string | number | symbol, any>`:

```js
const a = Symbol("a"), b = Symbol("b"), c = Symbol("c");

defu(
  { [a]: "a", [c]: ["a", "b"] },
  { [a]: "bbb", [b]: "c", [c]: ["c", "d"] },
);
// actual:   { [a]: "bbb", [b]: "c", [c]: ["c", "d"] }   ❌ base object's symbols ignored
// expected: { [a]: "a",   [b]: "c", [c]: ["a", "b", "c", "d"] }
```

## Cause

The merge starts from `{ ...defaults }` (which *does* carry the defaults' symbol keys over via spread), but then only iterates `Object.keys(baseObject)` — which excludes symbols. So the base object's symbol keys are never merged, leaving the result asymmetric: defaults' symbols survive, the base object's don't.

## Fix

Iterate the base object's **enumerable** symbol keys alongside its string keys (matching the enumerability semantics of both `Object.keys` and the `{ ...defaults }` spread):

```ts
const baseKeys: Array<string | symbol> = [
  ...Object.keys(baseObject as Record<string, any>),
  ...Object.getOwnPropertySymbols(baseObject as object).filter((symbol) =>
    Object.prototype.propertyIsEnumerable.call(baseObject, symbol),
  ),
];

for (const key of baseKeys) { /* … existing merge logic … */ }
```

Symbol-keyed values now go through the exact same merge path as string keys (override, array concat, recursive object merge). The `__proto__` / `constructor` guard is unaffected (those are string keys). Non-symbol behavior is unchanged.

## Tests

Added a `should merge symbol keys` test covering override, pass-through, and nested-array-concat for symbol keys. Full suite passes (`24 passed`); `oxlint`, `oxfmt`, and type checks are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Merging now includes enumerable symbol-keyed properties in addition to string-keyed properties.
  - Symbol-keyed arrays are merged consistently with existing array behavior.

- **Tests**
  - Added coverage for preserving and combining symbol-keyed values during merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->